### PR TITLE
add exit status handling

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -7,6 +7,8 @@ local config = require "core.config"
 local style = require "core.style"
 local View = require "core.view"
 
+local process = require "process"
+
 local TerminalView = View:extend()
 
 local ESC = "\x1b"
@@ -22,11 +24,15 @@ local COLORS = {
     { ["dark"] = { common.color "#d3d7cf" }, ["bright"] = { common.color "#eeeeec" }, ["name"] = "white" },
 }
 
+local CONNECT_MSG = "[Starting terminal...]\r\n\n"
+local TERMINATION_MSG = "\r\n\n[Process ended with status %d]"
+
 function TerminalView:new()
     TerminalView.super.new(self)
     self.scrollable = true
 
-    self.proc = assert(process.start({ DATADIR .. "/plugins/terminal/terminal" }, {}))
+    self.proc = assert(process.start({ USERDIR .. "/plugins/terminal/terminal" }, {}))
+    self.alive = self.proc ~= nil
 
     self.columns = 80
     self.rows = 24
@@ -249,6 +255,8 @@ function TerminalView:new()
             core.log("Please don't crash!")
         end,
     }
+
+    self:display_string(CONNECT_MSG)
 end
 
 function TerminalView:delete_current_line(mode)
@@ -288,7 +296,17 @@ end
 
 function TerminalView:update(...)
     TerminalView.super.update(self, ...)
-    local output = assert(self.proc:read_stdout())
+    local output = ""
+    local currently_alive = self.proc:running()
+    if currently_alive then
+        output = assert(self.proc:read_stdout())
+    else
+        if currently_alive ~= self.alive then
+            self.alive = currently_alive
+            output = string.format(TERMINATION_MSG, self.proc:returncode())
+        end
+    end
+
     if output:len() > 0 then
         self.log:write(output)
         self:display_string(output)

--- a/init.lua
+++ b/init.lua
@@ -31,7 +31,10 @@ function TerminalView:new()
     TerminalView.super.new(self)
     self.scrollable = true
 
-    self.proc = assert(process.start({ USERDIR .. "/plugins/terminal/terminal" }, {}))
+    self.proc = assert(process.start({ USERDIR .. "/plugins/terminal/terminal" }, {
+      stdin = process.REDIRECT_PIPE,
+      stdout = process.REDIRECT_PIPE,
+    }))
     self.alive = self.proc ~= nil
 
     self.columns = 80

--- a/terminal.c
+++ b/terminal.c
@@ -1,6 +1,7 @@
 #include <pty.h>
 #include <termios.h>
 #include <unistd.h>
+#include <sys/wait.h>
 #include <poll.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -10,7 +11,8 @@
 int main() {
     int master;
 
-    if (forkpty(&master, NULL, NULL, NULL)) {
+    pid_t pid = forkpty(&master, NULL, NULL, NULL);
+    if (pid != 0) {
         struct pollfd fds[2] = {
             { .fd = master, .events = POLLIN },
             { .fd = STDIN_FILENO, .events = POLLIN },
@@ -18,17 +20,25 @@ int main() {
 
         char buffer[BUFFER_SIZE];
         size_t length;
+        int status;
 
         while (1) {
             poll(&fds[0], 2, -1);
-            if (fds[1].revents & POLLIN != 0) {
+            if (fds[1].revents & POLLIN) {
                 length = read(STDIN_FILENO, &buffer[0], BUFFER_SIZE);
                 write(master, &buffer[0], length);
             }
-            if (fds[0].revents & POLLIN != 0) {
+            if (fds[0].revents & POLLIN) {
                 length = read(master, &buffer[0], BUFFER_SIZE);
                 write(STDOUT_FILENO, &buffer[0], length);
             }
+
+            if (fds[0].revents & POLLERR || fds[1].revents & POLLERR)
+                return 1;
+
+            waitpid(pid, &status, WNOHANG);
+            if (WIFEXITED(status))
+                return WEXITSTATUS(status);
         }
     } else {
         setenv("TERM", "xterm-256color", 1);


### PR DESCRIPTION
When bash exits the terminal passthrough will just wait for more data.
This can be fixed by `waitpid()` the child while polling.

Some descriptive message is also added to the Lua part of the plugin.

I also remoed the `!= 0` because ccls was complaining about operator precedence.
It _shouldn't_ be a problem.

**EDIT**
and also, `DATADIR` shouldn't be used. Plugins should be installed in `USERDIR`.