### PR TITLE
Custom shell support

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -43,7 +43,6 @@ function TerminalView:new()
       stdin = process.REDIRECT_PIPE,
       stdout = process.REDIRECT_PIPE,
     }))
-    self.alive = self.proc ~= nil
 
     self.columns = 80
     self.rows = 24

--- a/terminal.c
+++ b/terminal.c
@@ -1,13 +1,12 @@
 #include <pty.h>
-#include <termios.h>
 #include <unistd.h>
 #include <poll.h>
-#include <stdio.h>
 #include <stdlib.h>
+#include <errno.h>
 
 #define BUFFER_SIZE 256
 
-int main() {
+int main(int argc, char **argv) {
     int master;
 
     if (forkpty(&master, NULL, NULL, NULL)) {
@@ -32,6 +31,7 @@ int main() {
         }
     } else {
         setenv("TERM", "xterm-256color", 1);
-        execl("/bin/bash", "bash", NULL);
+        execvp(argv[1], &argv[1]);
+        return errno;
     }
 }


### PR DESCRIPTION
This would use the `SHELL` envvar or by default `/bin/sh`.

It'll also allow users to accept other command line args.