### PR TITLE
Errors on version and on line 450

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,4 +1,4 @@
--- mod-version:2 -- lite-xl 2.0
+-- mod-version:3 -- lite-xl 2.0
 local core = require "core"
 local keymap = require "core.keymap"
 local command = require "core.command"
@@ -447,7 +447,7 @@ function TerminalView:draw()
 
     local offx, offy = self:get_content_offset()
     local row_height = style.code_font:get_height()
-    local col_width = style.code_font:get_width_subpixel(" ") / style.code_font:subpixel_scale()
+    local col_width = style.code_font:get_width(" ")
 
     for row = 1, self.rows do
         for col = 1, self.columns do


### PR DESCRIPTION
Got these two errors:
`Error: .../redlolz/.config/lite-xl/plugins/lite-xl-terminal/init.lua:450: attempt to call a nil value (method 'get_width_subpixel')`
`Error: .../redlolz/.config/lite-xl/plugins/lite-xl-terminal/init.lua:450: attempt to call a nil value (method 'subpixel_scale')
`
Apparently the font renderer got removed in e25f2e9c5c1e165aa2c57d915894d19bb1eff198 so get_width_subpixel() and subpixel_scale() are not present anymore, this quick change seems to work.